### PR TITLE
Fix bug gh 27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # WProofreader plugin for CKEditor 5 Changelog
 
+## 2.0.5 – 2020-05-25
+
+### Bug fixes
+
+* WProofreader UI can't be opened if the tracking changes mode is toggled on. [#27](https://github.com/WebSpellChecker/wproofreader-ckeditor5/issues/27).
+
 ## 2.0.4 – 2021-04-29
 
 Internal changes only (updated dependencies, documentation, etc.).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspellchecker/wproofreader-ckeditor5",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webspellchecker/wproofreader-ckeditor5",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Multilingual spelling and grammar checking plugin for CKEditor 5",
   "repository": {
     "type": "git",

--- a/src/wproofreaderediting.js
+++ b/src/wproofreaderediting.js
@@ -20,6 +20,7 @@ export default class WProofreaderEditing extends Plugin {
 	 */
 	init() {
 		this._addCommands();
+		this._enableInTrackChanges();
 	}
 
 	/**
@@ -30,5 +31,20 @@ export default class WProofreaderEditing extends Plugin {
 		this.editor.commands.add('WProofreaderToggle', new WProofreaderToggleCommand(this.editor));
 		this.editor.commands.add('WProofreaderSettings', new WProofreaderSettingsCommand(this.editor));
 		this.editor.commands.add('WProofreaderDialog', new WProofreaderDialogCommand(this.editor));
+	}
+
+	/**
+	 * Enables the {@code WProofreader} commands in the Track Changes mode.
+	 * @private
+	 */
+	_enableInTrackChanges() {
+		const isTrackChangesLoaded = this.editor.plugins.has('TrackChanges');
+
+		if (isTrackChangesLoaded) {
+			const trackChangesEditing = this.editor.plugins.get('TrackChangesEditing');
+			const commands = ['WProofreaderToggle', 'WProofreaderSettings', 'WProofreaderDialog'];
+
+			commands.forEach((command) => trackChangesEditing.enableCommand(command));
+		}
 	}
 }

--- a/tests/mocks/mock-track-changes-editing.js
+++ b/tests/mocks/mock-track-changes-editing.js
@@ -1,0 +1,37 @@
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+
+export class TrackChanges extends Plugin {
+
+	static get pluginName() {
+		return 'TrackChanges';
+	}
+
+	static get requires() {
+		return [TrackChangesEditing];
+	}
+
+	init() { }
+
+	destroy() { }
+}
+
+export class TrackChangesEditing extends Plugin {
+
+	static get pluginName() {
+		return 'TrackChangesEditing';
+	}
+
+	constructor() {
+		super();
+
+		this.counter = 0;
+	}
+
+	init() { }
+
+	enableCommand() {
+		this.counter++;
+	}
+
+	destroy() { }
+}

--- a/tests/wproofreaderediting.js
+++ b/tests/wproofreaderediting.js
@@ -3,9 +3,10 @@ import WProofreaderEditing from '../src/wproofreaderediting';
 import WProofreaderToggleCommand from '../src/wproofreadertogglecommand';
 import WProofreaderSettingsCommand from '../src/wproofreadersettingscommand';
 import WProofreaderDialogCommand from '../src/wproofreaderdialogcommand';
+import { TrackChanges } from './mocks/mock-track-changes-editing';
 
 describe('WProofreaderEditing', () => {
-	let element, wproofreaderEditing, testEditor;
+	let element, wproofreaderEditing, trackChangesEditing, testEditor;
 
 	beforeEach(() => {
 		element = document.createElement('div');
@@ -13,17 +14,19 @@ describe('WProofreaderEditing', () => {
 
 		return ClassicEditor
 			.create(element, {
-				plugins: [WProofreaderEditing]
+				plugins: [WProofreaderEditing, TrackChanges]
 			})
 			.then((editor) => {
 				testEditor = editor;
 				wproofreaderEditing = testEditor.plugins.get('WProofreaderEditing');
+				trackChangesEditing = testEditor.plugins.get('TrackChangesEditing');
 			});
 	});
 
 	afterEach(() => {
 		element.remove();
 		wproofreaderEditing = null;
+		trackChangesEditing = null;
 
 		return testEditor.destroy();
 	});
@@ -43,5 +46,9 @@ describe('WProofreaderEditing', () => {
 
 	it('should add WProofreaderDialogCommand command', () => {
 		expect(testEditor.commands.get('WProofreaderDialog')).to.be.instanceOf(WProofreaderDialogCommand);
+	});
+
+	it('should enable WProofreader commands in the Track Changes mode', () => {
+		expect(trackChangesEditing.counter).to.be.equal(3);
 	});
 });


### PR DESCRIPTION
This PR fixes next GitHub issue: [#27](https://github.com/WebSpellChecker/wproofreader-ckeditor5/issues/27).

Updates a version of the plugin to 2.0.5.