### PR TITLE
Update `exports` in `package.json` and bump `ckeditor5` and `ckeditor5-dev-*` packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
       "types": "./src/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./*.css": "./dist/*.css",
+    "./*": "./dist/*",
+    "./browser/*": null,
     "./src/*": "./src/*",
     "./theme/*": "./theme/*",
     "./package.json": "./package.json"
@@ -48,10 +49,10 @@
     "wproofreader"
   ],
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^40.2.0",
-    "@ckeditor/ckeditor5-dev-build-tools": "^40.2.0",
-    "@ckeditor/ckeditor5-package-tools": "^1.1.0",
-    "ckeditor5": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
+    "@ckeditor/ckeditor5-package-tools": "^2.0.0",
+    "ckeditor5": "^43.0.0",
     "concurrently": "^8.0.1",
     "css-loader": "^6.7.3",
     "eslint": "^8.40.0",
@@ -63,7 +64,7 @@
     "webpack-cli": "^5.1.1"
   },
   "peerDependencies": {
-    "ckeditor5": ">=42.0.0"
+    "ckeditor5": ">=43.0.0"
   },
   "types": "./src/index.d.ts"
 }


### PR DESCRIPTION
⚠️  This PR is a prepared to work with new release of CKEditor5 in v43.0.0 (that will be released within a dew days). ⚠️ 

What has changed:
1. The global names for the `ckeditor5` and `ckeditor5-premium-features` packages in the UMD builds have been changed to `CKEDITOR` and `CKEDITOR_PREMIUM_FEATURES`, respectively.
2. Update the `exports` field in `package.json` to fix issues with loading CSS in older bundlers.