### PR TITLE
Update imports for CKEditor 5 v46 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "@webspellchecker/wproofreader-ckeditor5",
       "version": "3.1.3",
       "license": "MIT",
+      "dependencies": {
+        "typescript": "^5.8.3"
+      },
       "devDependencies": {
         "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
         "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
         "@ckeditor/ckeditor5-package-tools": "^2.0.0",
-        "ckeditor5": "^43.0.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
         "concurrently": "^8.0.1",
         "css-loader": "^6.7.3",
         "eslint": "^8.40.0",
@@ -456,169 +459,184 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-43.0.0.tgz",
-      "integrity": "sha512-pwhr46NNLOEyF2Qob/x4+Mwt6Bqi9i/j/4JaI5fSdhml8CZQHw5levJB3NRrOUX1zOw4cjZXQDU+j4TAN+l3xw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-LDuBb7DCEXsqCbePTda3yVZjGARbkZE1j+EQylu0zXK9vh/hY7W2P6ur6kTtNHz+A358PQ+3Vt1zLVap7UfpZA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-upload": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-43.0.0.tgz",
-      "integrity": "sha512-GxLw0l/l+CnqDavcHciegjmKsR4nZCMlrIdlvxPrQXAZOU2/EEEQE95UPVwbJCvIX4BB3LgF31FBbiDMWT3jbg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-N8289hF3fsgN/TdEKacnMvNnuau9oqlCcONPle4MiQt/lmI3t+C8WucfAmWUExIQAmYSpARhhvdhd7AjPEcLWg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-43.0.0.tgz",
-      "integrity": "sha512-wCPNWhgnUQctU7c8JdDVbf9m8Ai1dugvnFnR7xTLY3SLh7LvUCF0q0QQ4CysHdNVGSoGVJBmdjU7Qg3qNwD9Ng==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-yENBSRZ2rjy4FQSyOd6dm7AGfgQuTrHW6Kfnb3c6rUplt94M5HMqcwzozvxXa2FGTrynqV/ejzmeVTgo9hS99w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-43.0.0.tgz",
-      "integrity": "sha512-tqOH9ihcSpErDD9tYCDuIBnWNkAlti3b9gknpNj1cc3JSFbIcyX9KAsSFP49qMgaA1An95UyNTo7YunZgOp5sw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-MV3GXIYNnZKxT0S0Vq69Li085cnTZPUPc6PtBO9848Y2rqjllUP3poIcRm4FCFzCVXkx9nFAtqEYH0aNEUOQ0g==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-43.0.0.tgz",
-      "integrity": "sha512-L3kMP+uDvmkoAtkZO/cvJz4zvbnES1OQYmSipkq2YKZfyAtajj2FWHJ9Xy58D6TRN7RlgoN4WeM4jA0VghNcXQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-cB8W/QpFZTdLVD0vh9jNJQJ5d8qwbdRvDuf3ikKj2vwP7yC7s52/OtfAbNB+6ckHRS/pRVug61eT/DFfyZbK7w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-43.0.0.tgz",
-      "integrity": "sha512-FispEZZOZTpau6L3ft+hbpOqi1nDSrPRdEl4oObcHXdisHEYrTdfPXUtGDlcCcaU5mekNzVt4BNRikx2wNP9oQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-oV/TuoF2uWX/iUbdKMZzuCOuv0dPGpuAyoligAPzRfW/KBc4iLYClZ02fn9J2d0x4PylEO79tKaIct8JFd/OkQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark": {
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-rI6GAuiW9+K1fc2dpMsBIN/aW2cJ+0DxaA8gbJlefvwqFHM0GMrYXWDBwOs93JO3N7Ygxcpz6qWdrZfJyggFSg==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-link": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-43.0.0.tgz",
-      "integrity": "sha512-dvTgYbn1+EObVoW93rOrLJHlIwAy0/4trLibTTIuwjhKU3IeVW1vH4/UIgXV8Q45CCi5vypLBxzU5V9/bzzcDg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-Z+7JH//ukqFEP8UFz4BCxyIXGoUg0IcJlBZsxfi329jbvXCZH/vvUfGHtplF7+yhM4ngr7RoJH1fg5hdBzMgnA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-upload": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
+        "@ckeditor/ckeditor5-cloud-services": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
         "blurhash": "2.0.5",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-43.0.0.tgz",
-      "integrity": "sha512-YZv2AO9my3HBv/J6pOSjkMgVxl6fkUuT7Ify6Wp6ixQFCy1nPPR7s3W3WQX4+d0BPEXcz602A1PylCESYWwFfA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-f/XuuVZkuFu0KEEwSvsaQcXaUC04MbgVYNNfGMy9bvOdZS1Wrj6tD/6btPKYJpO8qSNSfsj/uOT4cC8brqtgvA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-43.0.0.tgz",
-      "integrity": "sha512-z0A800Acmd1bfY2bi69OB2xBVNZFeqRNRfWyIX+kdP3+kA+tkb6ypMhAc0XMC2cstBcTKUSPEk7HufgD0k8gTw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-BSG8EZR9+mmY0MaE/laTlMEyM2s3HWXdcxPzRr9XSuTDKMPu6I6T0MHxNdZGdYTTM6bq4gtDhZVLt6sg3CIjtQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-43.0.0.tgz",
-      "integrity": "sha512-cJ0nwSZNRyX69Ky0M8xIjLzxTJz7E1JJ52TBkzGogV1D2XogiC2eXUMHZDi6zoiBP5KyB84d4trBIxUs0ElaEQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-2PyvFNtY8/NuQ6uTKoBXwTYPeMj9mBoJKoLioDwxWH39Tqo83RPQjuB8/+0V7YsJU5VvpMhRBLPZR07Rji5eUA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-43.0.0.tgz",
-      "integrity": "sha512-gQJaMQdEvHtqG7KsCpWawSnVJeH+aLzgETYEuiWxWkJPXqKpE/gzq/XSRxqoyIoda6YWz2gfxCDZckVAHXa9Pg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-X3FdRVzO1m4VtlHh6N6utqd1WdQwObxBz9wnr5tNGpdTyzXF2Kzn5veXA6kCL1/mceZR7IvBU9qOu8ywlLtspA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-43.0.0.tgz",
-      "integrity": "sha512-UbOnWwB8RIjipDTuFCPVqJtSnIhuCf5DCUa+05JqMdKzlqj3pJC+iBsvGbxtk6DdzSr8q1CUHwhJxlXfs3BSLg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-qKaIsCjdqc1NTtzNuY/p3uXNSCkujS4Ol57D2IQNCWfJfejCJIS5Yy9EwroOtAe/5PixZ3Oh2DtyrAe5JIxNRA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-watchdog": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-watchdog": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-build-tools": {
@@ -1788,374 +1806,411 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-43.0.0.tgz",
-      "integrity": "sha512-iT+g9lrBvKreHjRP7tc8P/LrzHEtipBQ488eJdtmaNvMUIQvFnjhZOIcYd7Lr+a4M7+qJl8tSwJOQvM/KiXDeQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-GbN90wSE6o6rqvg8uivy10iunLRGbB3TLi/8XxwAB1LG3Sc8QhdHNQwngX1/3GPm5OvJgiTb8FI2VgfpWjoKGw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-upload": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-cloud-services": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-43.0.0.tgz",
-      "integrity": "sha512-D8tJ/ZKezsc0m75/kzSS783VB8tRiWabmzJUOtlFGss8RwD3QZqHCabP/boZW95vEm/sk5UZt2COL43jlNN4TA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-BZL5Ra7DeTrCN8O2CGqsCEx1J/qpwAgFf5B9kYaurK74Vv/sV0xFsTsDPph9UWGJLX128QK8GWPulRiDo1DXwA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-43.0.0.tgz",
-      "integrity": "sha512-VUewScFqwQxm5tu2YPMNzX6pVb3HaXGyEL1PbKo8gBtmo8eimsfNS6WbW2gn4RhQKyu2BzFKXeaNi9Dj0aTZLA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-eJPI4ywjn50VMRBDGD3eZe11kX1wbRojVU4bDOkVkCL0Xv1gK+fsgBvII74mYUQBBJB+J32Ktd+AA2s9ogya+w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-43.0.0.tgz",
-      "integrity": "sha512-BVrMPXCrHMDaxxEuLiUhma4Kx2huSnp7u5EoWaDxAVOXjpb3ZRlboGV5smpt87BmjP5Zt58SrUsDoHnLPfN6eA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-imxu8XUSJ8lM24I3V8c4ME8bKFTRN0H5yIOU3O1Okch5WuSfieyWwjfn6wyl6mLPThH0JjB9Z/3qluUyt93pnw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-43.0.0.tgz",
-      "integrity": "sha512-II77SDB23t02Kbapf74W0gR8QpNCeVm7g7IT6NvGF1OW3RlTwDJQsfdyOgvHQoU4FkdRoOIEOoeFbJxgToJORw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-itQOKznXoGad7lhGCLCpAz9z3r/cMGQOBpfBP8Ug3Dk1QjqsvLlXtGV5brI7NJ5qi7oMKBRTceN9x7Q22psvkw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-43.0.0.tgz",
-      "integrity": "sha512-9J48bxr8H0iD98QYEdBrfyIGXcX1v0jQN3w9kuT2Una/GgnBRM+EiN2N9vM+xu6arBSA30aZCqU5u0mv2DPAGg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-IVun5YGbC4wh2SxSaxovJCSj7ehsCTHfu8jzojb8tCULjUNo4PTjflil5zLP7hNcgI/hhjkm0lWNQSnBSYUFcw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-emoji": {
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-YEodQZFyCHx682D5I07qSRdKcuBRZo0SSn9Anq06tMW/64CpOnSL8d5oNqqTLXaOmYJR50a/WtccMTdcIi1pyw==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-mention": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0",
+        "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-43.0.0.tgz",
-      "integrity": "sha512-0CcNbxxNjrmxytBPjh49ZELwyoE8lFSCFx+44CGRicY+GYeg45+sIUiyY0rWiBaxukfVajl1sYlctDVGezP9Bg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-5Z/3l1Q/QBBUV+POPBsCkL0VLIiJ3jAg+n487uH5BKOkT84wApVtJxsvJaeNJR10Waar543htIMR9ZRhbFNgPA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-43.0.0.tgz",
-      "integrity": "sha512-E6ay1zfYOThTQoBISXL3Ez13dKsJXWz6AZV1z5tAq77N+pD0hBjX4uwwxhQ95Yto56Ifhy3l4zwNJTjePAD1TA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-Y4DcC48ujzoWKw3RM8sySV0IwX1PTlIJXo9rIjbH4qGQHGabmbtbF2nfYEWyK1Fvs8yFrq22Zs9cwF9PQ2iuRA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-43.0.0.tgz",
-      "integrity": "sha512-UGXxAhmod1QSM6t5ZEPklqBpoAHFqS2ZWXhGZdQaEVzt13MR+tZanug/+3XTs46yhM5401jKT7BGhfkUZwQnVA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-v4TMSui3lPS6G5si7Nw3w5id8ti6B1ik46vQ9A4GVASsIjnLfKUgxkOAkIk3yGjZIVdwGy+XGmiZi7Py1BDI4w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-select-all": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-undo": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-select-all": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-43.0.0.tgz",
-      "integrity": "sha512-/kD4gypGzuPqtun9IWA0ywNKJKJ9sllurqjRHOXagU5L19pakBr+KpuD7vKNN+NYN3gzyI9REMP6CEXSBb+c3A==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-lM+2eXHazwwWaCeqhWT3uwkqmmXL8VLB7QqgKNyiRe1Dwk4SBmVBpESkjEZhemT2v1F/GVgj/XljKD1pla/Htw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-43.0.0.tgz",
-      "integrity": "sha512-/B5Txk17+av2AsD3naq+yqOw6vdj2n8jA4+Zm0J8TerCRbwYELRyA9vBCwsGvVKkl56RfjzSNInFD/gKAn5Uzw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-hJTypKoD/xgQh+8JKgK2JDHiBbTavK5/OQj1c5R9f1EUBhgNkUtZnS13X2EiuHv6N8zilTJsl704LVmO2Mex8Q==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-fullscreen": {
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-9y6BVHUPyZCSzMOiWwFKLOGOI343x0dGKHJxdfYHDVr9JCvSDLqEtknc2iZnRLhYRTEu2Bj8efkZ/Kl7m1wMWw==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-classic": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-43.0.0.tgz",
-      "integrity": "sha512-15h4KH4LmH8h0udTI9Apvw4YuEopjx+srt/++Uxv/AasLfNSOMfZ8lIjhqieuqWjeCGotnV8sG3TPJDi55JOZw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-/PVdUOLTeXRN4ByI42immX7yDVVqTPg2SdGacAXgEyBJb5XvZ8j84g9dmRXsIQxTd3xk3m7Hul1S7/dKro0ewQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-paragraph": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-paragraph": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-43.0.0.tgz",
-      "integrity": "sha512-lzlIXS0/lB2eUCygzUJbNOU6YDXiIyAnZoFqx/qw4heU9DL33Omh+cSfBpSkm462OWbExUWoOkqHFtE3R8Qs8g==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-6T6AIhAEedMdfvo2g55qKMbJTa4Y+LDp6QOENriyMJrpUHdhU0DEaLieLIHECQBEbZG7aAgBPJHCU1JiQsqVxw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-43.0.0.tgz",
-      "integrity": "sha512-yYsfSjEPW0enbXKntf8OA9G4xQGEKp6m+Dph8asuCIakpET21oUkeVYWDgRlf5in0Qabk5Ymv/UkSWdUaPiVew==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-OC4yG2RMSLSPNXorY9JbBCBrazWzbLxLiIwNVgtY5c6qOzEkbTVIztYbNXTExlpZFDijeHSOSHKKCQ5CwrO86w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-43.0.0.tgz",
-      "integrity": "sha512-KWjZkw9leOzO81xYLqHqhJK7DhrW1qxrfQ2blD3XRI4aXcFQXniLCDXugkLOTzjkbWUhXUbyWt6tM3gPqgX1jQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-KJ0ZxymcJ6oLyvymMiq2W9bxI0ndhKkGkHjbyL8aXx3Hzm/UHKEycok76+Uc++iaR2PF0/NbcYgJN17hIc7M0w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-43.0.0.tgz",
-      "integrity": "sha512-Ji5zaG17wgJRSpXe3FNBD1rEmqLb6Jh1+RJX2/+rIV3ph0ZhP5FKESz8PPw48bPjns5sjd5RCdalv9UIKpz5eQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-vXwr5WxBZP3+dYifYPtWue/4BS/FercP+VzuUUq6pvo+zmhzAnOrvFbeJy+SAiEB6ke4pHNtcY4HIl4eFlVSZQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-remove-format": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-table": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-icons": {
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-lXxrePETNsRIx4SFnlWwVryHoBnf86bXlImT/IuCGiGRqpaNDjnSX1cOLR+Xr0sy2ZbMs9//a4ic658ie2dCNQ==",
+      "dev": true
+    },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-43.0.0.tgz",
-      "integrity": "sha512-UeO1yaDigz1md+xBt9wP1pp9ncotVL8TFkx3nxXvOqVG8FxWS+HdHZ5JwdG+yCrYiIJOPDJt2YiZ6HSkktF/6A==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-3voUJ+32K+sN++fQor7VUgthtQbh2BDhsH8cLD7NJMus/mF1O5UWwyIXy/MCOrl6rnc7c4wwoa/BbVP63Q+LuQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-undo": "43.0.0",
-        "@ckeditor/ckeditor5-upload": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-43.0.0.tgz",
-      "integrity": "sha512-GnG9LsVWXE8Otyxt3ZN4Ild4yYNHy06sQwcRSuByPePKzFb34l/0AfH8IqLJv8SQT/z35Tb7K64zKOriZFX53g==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-pfuM9jOvAjcMSy+984nlrjPwEc6y2nOzXu685NcCwzROxIhnl4taLmN15QNSucM9WWVQtDd3tEFTjSPWL+05gw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-43.0.0.tgz",
-      "integrity": "sha512-NcVmgB9YXyrHqbj5QUpKJZztj/eEN5k1RkLOhQNA4IDw6UvNp5uSkum5AxtpwcjDaE10UHQIYDBQIwGSRAUL5g==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-XzyA4qfy07I4+NfrShmzZT9of9n6uwF0/YhE3cUaZLcqK2NfjeJfT8zVa7z3WLf9yrNuflK9c7kGdLRoD3cbsQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-43.0.0.tgz",
-      "integrity": "sha512-BAkjg+bfiYCPOvK7WLLlqL2Hy0tcNVgspWLRNr3RJWhCSZMEbtgF8DR97mRA/vWkzTR/htNGKXlbp7OOmBk2Pw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-qrDNm1jX0npnQ8CwiPcdfy1uVVIdeyVGs2D8xgKhJDoLw1ldkd/NM1dYuXwIkfEERNOxgt1FnCGcZcH/Jh+0TA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-43.0.0.tgz",
-      "integrity": "sha512-pBEI7UNNmO8egc97f1oNHZZvDzZn0TAVzxpYifQcUsVwnsobFk9pojQIpEdJjKoPWcIMJO6SfHe+DYvrB2kqPg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-8UihRjJTCgT41o8Dx6xDa+Xo7k9McoC5mCKP9tz4r3/boX9mPd9WoRZgyJUqND0WsMyCXCVGBcrdh0iJI/iEng==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-43.0.0.tgz",
-      "integrity": "sha512-4TjnTugDEMoxLej/dmiUxqKEwGqmPACuwU1SnSR15E5X7MR+0SHAdXg/sQfJcbmwrjle/6tSp4NVK7XKPi7Sug==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-geO9oeEpw6uqsanfLdbcCIof25V50GLW4U95faITkE54HGzUw6vEtK5nuji/R+LeCpVAW3dY4rrS3Nfkr8mnig==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "ckeditor5": "43.0.0",
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@types/marked": "4.3.2",
+        "@types/turndown": "5.0.5",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
         "marked": "4.0.12",
         "turndown": "7.2.0",
         "turndown-plugin-gfm": "1.0.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-43.0.0.tgz",
-      "integrity": "sha512-l+BlHpS88yZ0J25KqfXADgb3AYXuAt5yTzYwN8XCMQ0/HbjKmgb/Hkppo5Bcd/hzSBG+LUh1dygP1F2lkc5N/A==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-BA+wdcH0GYYS4sz7YqoOhlTz9FeDuZntKAefrpqLr5HCoyzU8DDruLnULtWVb8ZsB3X8OCBq1TsIff5AOTLg4Q==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-undo": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-43.0.0.tgz",
-      "integrity": "sha512-B5DNmfj1JbLLx5+6vnneoK+C0BLPjiM+5x1qdpLVAMIWkbr6qJCthZfe5gnGD7WoGpRILIE//cskm42eP26wcQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-Z6V6m2qTwIgLi8KTz6ZyD6Fhs2etSQZ1JODqOym3AB7OBFxPB5P0z+bTVjT44SBM80ar44OAZhD+GwEOzKdKSg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-43.0.0.tgz",
-      "integrity": "sha512-2C59bqoVBOTnbccsgpCyie+sGKTl/J5nIt5Wu1oyINYPT+j+VjUtiSh5yZKPRXTF+Cyba6NyFU/56BJLBnPurQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-Y/AJiOuaq6AAnz2jDP8SbLug5lkIOtnkuooWLjOG9Rfv7m4PRx/2H9ZEpMeI1rmUKBIGRywKrPqMBaAnaKaSLw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-package-tools": {
@@ -2587,263 +2642,292 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-43.0.0.tgz",
-      "integrity": "sha512-oSHGAPBHrs2pRwAp36ldVn3fy2xySzDmMXNArnpiRbwIScQOZHuf/iqAIPeeZkO27Gfo9bfh/oWbGcUfPBzF6A==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-6ZhETn10kL8wWY8PrsN00p6WsZ6Ea5bKjNCLnyTmRoskkr0krcrA/PirRdl/lkqzNOhSEhP58GAplwLpSISH6Q==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-43.0.0.tgz",
-      "integrity": "sha512-xt8x4E6Vh0dmFxbCtv89KdKoSM+xB6B8s7q+Mvf/a/gtnV/x1OJgMBBTUj81FRYtMVB5LyQsE8Wo8jNLYzHmTQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-sVyb2KqXBO/Kxxws9wWEM7aKmjj0Y+zrc+qh4jfFtAfu2JfoieERogt2SeQAVHeEqxTdP6xXnUX6ME4o4pSmxw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-43.0.0.tgz",
-      "integrity": "sha512-VMONY8JUdSfWQ0GNjtpjqWvA1BGunIqhDp4dIvbSyiAoK/3p7QQfjdAm9OOxHIwyns5gO5+sBiEHC5GZadgSMg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-njuV+RVR7nZHwqUy9H75sNgWhbHxfhYsTIZvgf+SVTiEBHJRHg9eahaDal0RjcvEJkT9Wib36uqJheYa3NjRBg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-43.0.0.tgz",
-      "integrity": "sha512-q27Zqie8WJXk9XGp5CFaGZ8JMyLczhdGU/kyeeX9A5FcCDxpR2nYOgtq0BGgt14XTa2Hr0IKM8NIfdyxA29YNA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-iraCnKlUMmmOtH5Tekkb6jBnNNIP8gkZexOHMqfN6Mpr/RQ51+Cf+wjXyQ+R/zkA7h5LieETwgP/n0uG0a8lOg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-43.0.0.tgz",
-      "integrity": "sha512-zMX3ONNZ1jKKfT41PERvJOr79ciZYxCQjhBkCHQE6xe1VhU5QFfPibvZRj+KEHI6CBhxGrwo0In0YaLLIHbUuQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-YkT4clGKBOP5922iILP7MaDvIOpCGeQwX6c7G8asRchsz9bGeiJ/9q7GyDZWR9WqofocpsmVJKFes+UdFAWctw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-43.0.0.tgz",
-      "integrity": "sha512-ABPFd6cVeef5tWXtnv3ZNdCK1WcCEH48Gm8o84S+ZwQ0wW6y3CY3EW6QVCIL1sqBzgLY8NBBCgGvS7Ymn7fv4A==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-zRFWNP2peluVyFYt6ndpfC46hjI5eEiBwVjw+L6Nh6VpfMiToX+h4NpxONnO1kHiVKfaNVJ395vXgml9noYarA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-43.0.0.tgz",
-      "integrity": "sha512-KX0nfY1Hhs++fv/mgy4+lJxT78ekOwSecLURpX3Mzs4j7AAek424D7itlP5r1wPK9e7ozPd7+AmUYHCuesSD4w==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-YOTtfOZ68gcSl9HSOXuz3jjyslIipK20SuBbyukGoGU0onMoDb0ALZxLeQtHAJ76GXtTbhVzkg9i9sNBVu6P5w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-43.0.0.tgz",
-      "integrity": "sha512-Go9lDGoB26d0Rb7D329I54NHO4T28c4grqx6KVjO0R8nmugfcSpITBLdSn/KarDJA1ysIsbN7k/p5guuiVWTMg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-6a7LoIZ9/5xL4FC0TSqj5iQBI1WXrNg0mJTrBeUKBo0apsoKY5VhnOZ330rRnzSdxMBw/DNnHw0BfpWoJOQ9Kw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-theme-lark": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-theme-lark": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-43.0.0.tgz",
-      "integrity": "sha512-5l2SdmYEBbid15xUo/L/UjzuxFODNEhNvv4mXIZZOX0tkJ6UNlF1jt5wMjFjWrfFUsZdUwj/aC/7FutotWeHrQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-mOZx+/50mexVEMMoBEBt0O6SSEsuDmPF7so6ID8xVj7mL9h+kPt9M06ShjwSQMNB9BYsgoKKNedQ/s/MDnEGVg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-43.0.0.tgz",
-      "integrity": "sha512-9obmKXVQWsg/Ly25ggXyO92GrHp3lIcJ8vjEkbQU/8PO2pblhEylLJEPIRWSySNKYkw0d2fsSDKjC5c3Brx/Gg==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-D2M60e/ODk2eknKOD+Vc87JENTmBIG2vsIWT9/xZYE4k09DOfTulIytWrcDH1SzZm+4aq8OKe2vYgC3xZcX3GQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-html-support": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-table": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-43.0.0.tgz",
-      "integrity": "sha512-yHru16jsCG7Zr71hWVvCFyc08ol2dbUNwV4wAZUmM27sYyW8ue6ATML6NQQUiL+7gwbm1xit/Gm9hxuRBtzz+Q==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-vdkrEvXdKjzFrq47g6q2gb1LeJON5Nco+9r+6gEhqVjXhxi0AgVMDL+Q4DgKZpsEJwr+YYmzduBMVvVAwgvHMg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.0.0.tgz",
-      "integrity": "sha512-cd66o/cdKFDhjMnhabgtrsl1K1cyRYzsQnS2459Ly7ApxreOF5w8MRQuGIfr7NmjDwu7xTo4CXowCxmRoxf3JQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-Vjva3bXNQ1vVz6AzB0GoOUz5uI9sRspWaxaIbCa0yVdz5geCG1poSbyqmoPDHmhkfX6bA1rywZLOfnCb9lXUOQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "43.0.0"
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-43.0.0.tgz",
-      "integrity": "sha512-OKXpo5NdM2ZAL4hJpL0SXdeEfWzZfcfFwRjmOSFOIhTH06wN2E77OQbdn1E6L3yyup+9iYBanL7BYjDBQL4/cQ==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-Jvtrw5/H1FzuG+qOGHcFjqk1b5b8AeZdycEZAIDuk+bO9sVoMRc+K6xaOf4rAYz+X6ReW1cR1IX0hxJlsDiziA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-43.0.0.tgz",
-      "integrity": "sha512-R77EeM3vbRWmVdCUPbw5ZfqQlz2UiOIrCnjkXEf1GQVFzn5THNejlUzf9QwL51GS8CquOyH8rg1iRPM9gQiGuw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-swGcmpddoSD8TTRXPIzCr9g+r+ML3UyHZvHHf2oNGariC4ReH6yyHxCloO3kYWw1/vYY9pQUM22DkpH/0Grp/w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "color-convert": "2.0.1",
-        "color-parse": "1.4.2",
-        "lodash-es": "4.17.21",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@types/color-convert": "2.0.4",
+        "color-convert": "3.1.0",
+        "color-parse": "2.0.2",
+        "es-toolkit": "1.38.0",
         "vanilla-colorful": "0.7.2"
       }
     },
-    "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-43.0.0.tgz",
-      "integrity": "sha512-FDLyZqxkcMqhodOHrYP/GTQWQuC3e9n1gg25nQYqR0IgEqrDU6TH+wTBMrvo6YHv3pl88IZsfNr2vj5ZnsKThQ==",
+    "node_modules/@ckeditor/ckeditor5-ui/node_modules/color-convert": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.0.tgz",
+      "integrity": "sha512-TVoqAq8ZDIpK5lsQY874DDnu65CSsc9vzq0wLpNQ6UMBq81GSZocVazPiBbYGzngzBOIRahpkTzCLVe2at4MfA==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0"
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-ui/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-undo": {
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-SP56siPhg9f/RgoXKsa6Po+mTU/Mvrlnwn0U2Wc/GpOmOuJp1UGeXZcySKctBfliH10lz1NKf1bVqKFG4Rt67w==",
+      "dev": true,
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-43.0.0.tgz",
-      "integrity": "sha512-IXryGBQFjw2wDz04UM8pbwjJETBxYCmyMz0WW7GJsNA04qO3evxlaCVGczb1nheRbbUb9SBU8wpHKPz05xMQdA==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-iEcdCX4H9oI5QPxwUIaOJttkzHwPF8kLj5PzVT2yiSVioCK+HeVxxMP4Cdx1HECl9SVazdp2kJ4orruel82dHw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-43.0.0.tgz",
-      "integrity": "sha512-xupNfpUX3EGVVRycijYGOZXTaWEebHPwEMAfI5rduYAUAf63AbTpL4s7sakxFaHp1SS3bQWN+j1QiXh/TBhRAw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-OBX4oeWumSl5y+MG18PH8ZPc2LuRtztJWP80vn98NU8e0fc0RVqy0w1OnBKqLuJmBXSo1qO+G9MpoVHQ+zRB3Q==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-43.0.0.tgz",
-      "integrity": "sha512-sS+mnuWGZWpe04YbpGZWy3MpMzZ2eFDn911jo0+7nGbypuH8cqrFSZBCUZ4DyE7ghsZ2P6CgMTsUtz4G+kjeZw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-us4XIM91JXl/OqfnJTHDrNpTyk9zGIEPDXrnEkduCMukCwKXPv42Gy62gTcGXGqzRdTDe8cZ+8hhA0ytxU3B3w==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-43.0.0.tgz",
-      "integrity": "sha512-jjRzj3jkieUxtTF2fGQVZCFi5Oq2gpkiJ77DaXEINNqyDx01d2mdIl/U0FnQbgfK/2bUf+1wp5qnT3Lwf4q5Jw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-2LqAMcso8bcVcI+frPd0lX8VbLOwt/wiOZIw27lDd2/u/QIWmScCDm1D0IvF+PIPyMReYnmbvRpXXuTZ3Kkvmw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-43.0.0.tgz",
-      "integrity": "sha512-AiqeuESUTCsNUPCoPzRq1BDAGqPW6e/9vZpZ0B0esDcshLddJ2oQk0bYyjvkpJ4GDNEwAwJyCN1yI7IYXGEBjw==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-UPnQZqDIt3JXLK9xSj4H1117OeB3Wm2HiXPG3n091amcRHcbUzW/MAB8J9qgkKI73bIsJ+0Ch8u5tUC0qke7sg==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "ckeditor5": "43.0.0",
-        "lodash-es": "4.17.21"
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "es-toolkit": "1.38.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -3563,8 +3647,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4396,6 +4479,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/color-convert": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.4.tgz",
+      "integrity": "sha512-Ub1MmDdyZ7mX//g25uBAoH/mWGd9swVbt8BseymnaE18SU4po/PjmCrHxqIIRjBo3hV/vh1KGr0eMxUhp+t+dQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/color-name": "^1.1.0"
+      }
+    },
+    "node_modules/@types/color-name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.5.tgz",
+      "integrity": "sha512-j2K5UJqGTxeesj6oQuGpMgifpT5k9HprgQd8D1Y0lOFqKHl3PJu5GMeS4Y5EgjS55AE6OQxf8mPED9uaGbf4Cg==",
+      "dev": true
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4521,6 +4619,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+      "dev": true
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -4640,6 +4744,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
+      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.10",
@@ -5590,8 +5700,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
       "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/body-parser": {
       "version": "1.20.2",
@@ -6089,69 +6198,72 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "43.0.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-43.0.0.tgz",
-      "integrity": "sha512-7amisPZrSPMuaSDRFVAz/BgplV5OzUpWs6jtFP6MNDh98QK/RLyGvm4vhxjEN5n2MCov/ZURphwYsKwStIX68Q==",
+      "version": "0.0.0-nightly-20250624.0",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-0.0.0-nightly-20250624.0.tgz",
+      "integrity": "sha512-uq3ZL7vSppEF4uTQwV12opfmSlUA96MiLxogsbAGC35jCDccL0t+ymqn6gYfZKtUmUdwP6WxdH7qohrnZcLakw==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "43.0.0",
-        "@ckeditor/ckeditor5-alignment": "43.0.0",
-        "@ckeditor/ckeditor5-autoformat": "43.0.0",
-        "@ckeditor/ckeditor5-autosave": "43.0.0",
-        "@ckeditor/ckeditor5-basic-styles": "43.0.0",
-        "@ckeditor/ckeditor5-block-quote": "43.0.0",
-        "@ckeditor/ckeditor5-ckbox": "43.0.0",
-        "@ckeditor/ckeditor5-ckfinder": "43.0.0",
-        "@ckeditor/ckeditor5-clipboard": "43.0.0",
-        "@ckeditor/ckeditor5-cloud-services": "43.0.0",
-        "@ckeditor/ckeditor5-code-block": "43.0.0",
-        "@ckeditor/ckeditor5-core": "43.0.0",
-        "@ckeditor/ckeditor5-easy-image": "43.0.0",
-        "@ckeditor/ckeditor5-editor-balloon": "43.0.0",
-        "@ckeditor/ckeditor5-editor-classic": "43.0.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "43.0.0",
-        "@ckeditor/ckeditor5-editor-inline": "43.0.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "43.0.0",
-        "@ckeditor/ckeditor5-engine": "43.0.0",
-        "@ckeditor/ckeditor5-enter": "43.0.0",
-        "@ckeditor/ckeditor5-essentials": "43.0.0",
-        "@ckeditor/ckeditor5-find-and-replace": "43.0.0",
-        "@ckeditor/ckeditor5-font": "43.0.0",
-        "@ckeditor/ckeditor5-heading": "43.0.0",
-        "@ckeditor/ckeditor5-highlight": "43.0.0",
-        "@ckeditor/ckeditor5-horizontal-line": "43.0.0",
-        "@ckeditor/ckeditor5-html-embed": "43.0.0",
-        "@ckeditor/ckeditor5-html-support": "43.0.0",
-        "@ckeditor/ckeditor5-image": "43.0.0",
-        "@ckeditor/ckeditor5-indent": "43.0.0",
-        "@ckeditor/ckeditor5-language": "43.0.0",
-        "@ckeditor/ckeditor5-link": "43.0.0",
-        "@ckeditor/ckeditor5-list": "43.0.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "43.0.0",
-        "@ckeditor/ckeditor5-media-embed": "43.0.0",
-        "@ckeditor/ckeditor5-mention": "43.0.0",
-        "@ckeditor/ckeditor5-minimap": "43.0.0",
-        "@ckeditor/ckeditor5-page-break": "43.0.0",
-        "@ckeditor/ckeditor5-paragraph": "43.0.0",
-        "@ckeditor/ckeditor5-paste-from-office": "43.0.0",
-        "@ckeditor/ckeditor5-remove-format": "43.0.0",
-        "@ckeditor/ckeditor5-restricted-editing": "43.0.0",
-        "@ckeditor/ckeditor5-select-all": "43.0.0",
-        "@ckeditor/ckeditor5-show-blocks": "43.0.0",
-        "@ckeditor/ckeditor5-source-editing": "43.0.0",
-        "@ckeditor/ckeditor5-special-characters": "43.0.0",
-        "@ckeditor/ckeditor5-style": "43.0.0",
-        "@ckeditor/ckeditor5-table": "43.0.0",
-        "@ckeditor/ckeditor5-theme-lark": "43.0.0",
-        "@ckeditor/ckeditor5-typing": "43.0.0",
-        "@ckeditor/ckeditor5-ui": "43.0.0",
-        "@ckeditor/ckeditor5-undo": "43.0.0",
-        "@ckeditor/ckeditor5-upload": "43.0.0",
-        "@ckeditor/ckeditor5-utils": "43.0.0",
-        "@ckeditor/ckeditor5-watchdog": "43.0.0",
-        "@ckeditor/ckeditor5-widget": "43.0.0",
-        "@ckeditor/ckeditor5-word-count": "43.0.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-alignment": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-autoformat": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-autosave": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-basic-styles": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-block-quote": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-bookmark": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ckbox": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ckfinder": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-cloud-services": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-code-block": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-easy-image": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-balloon": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-classic": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-inline": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-emoji": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-essentials": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-find-and-replace": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-font": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-fullscreen": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-highlight": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-horizontal-line": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-html-embed": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-html-support": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-indent": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-language": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-link": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-markdown-gfm": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-media-embed": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-mention": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-minimap": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-page-break": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-paragraph": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-paste-from-office": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-remove-format": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-restricted-editing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-select-all": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-show-blocks": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-source-editing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-special-characters": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-style": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-table": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-theme-lark": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-watchdog": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-word-count": "0.0.0-nightly-20250624.0"
       }
     },
     "node_modules/clean-stack": {
@@ -6295,13 +6407,21 @@
       "dev": true
     },
     "node_modules/color-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
-      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "color-name": "^1.0.0"
+        "color-name": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse/node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/colord": {
@@ -7673,6 +7793,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.38.0.tgz",
+      "integrity": "sha512-OT3AxczYYd3W50bCj4V0hKoOAfqIy9tof0leNQYekEDxVKir3RTVTJOLij7VAe6fsCNsGhC0JqIkURpMXTCSEA==",
+      "dev": true
+    },
     "node_modules/esbuild": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
@@ -8630,6 +8756,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/fuzzysort": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
+      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
+      "dev": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -11229,7 +11361,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
       "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -14444,9 +14575,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -16935,7 +17066,6 @@
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
       "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@mixmark-io/domino": "^2.2.0"
       }
@@ -16944,8 +17074,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
       "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -17077,11 +17206,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
-      "dev": true,
-      "peer": true,
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17359,8 +17486,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
       "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@webspellchecker/wproofreader-ckeditor5",
       "version": "3.1.3",
       "license": "MIT",
-      "dependencies": {
-        "typescript": "^5.8.3"
-      },
       "devDependencies": {
         "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
         "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
@@ -17209,6 +17206,8 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.1.3",
       "license": "MIT",
       "devDependencies": {
-        "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
-        "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
+        "@ckeditor/ckeditor5-dev-build-tools": "^43.1.0",
+        "@ckeditor/ckeditor5-dev-utils": "^43.1.0",
         "@ckeditor/ckeditor5-package-tools": "^2.0.0",
         "ckeditor5": "^46.0.0",
         "concurrently": "^8.0.1",
@@ -637,13 +637,11 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-build-tools": {
-      "version": "42.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-build-tools/-/ckeditor5-dev-build-tools-42.0.0.tgz",
-      "integrity": "sha512-YnlbXMLcgS+Ddq3WO9hkdJJ44toIkTy9Hm/fF3s7DVPgIVZxn4ND5NtEHtAHoztTHTF9sjpmldlaWqsHZQDjHA==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-build-tools/-/ckeditor5-dev-build-tools-43.1.0.tgz",
+      "integrity": "sha512-e4dyv/8MtmrcABlTMeCaBi/H+/axxXfYIPB6shOLP/ZXLOnz6j5AEuw+v/KsJja5Y+A7JPPg48H8twaB/KftIQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@fullhuman/postcss-purgecss": "^6.0.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -660,8 +658,10 @@
         "lodash-es": "^4.17.21",
         "magic-string": "^0.30.6",
         "pofile": "^1.1.4",
+        "postcss": "^8.0.0",
         "postcss-mixins": "^9.0.4",
-        "postcss-nesting": "^12.0.2",
+        "postcss-nesting": "^13.0.0",
+        "purgecss": "^6.0.0",
         "rollup": "^4.9.5",
         "rollup-plugin-styles": "^4.0.0",
         "rollup-plugin-svg-import": "^3.0.0",
@@ -1552,11 +1552,10 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-translations": {
-      "version": "42.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-42.0.0.tgz",
-      "integrity": "sha512-qdme0GXrefAH+7hpBNRnU7nxXsUWvrLrc/AnbsWr+4pjsoU4NXHHdjLqJdlQE0u371LlYjj+HYZ/V50NdeHzIw==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-translations/-/ckeditor5-dev-translations-43.1.0.tgz",
+      "integrity": "sha512-dIjau68aLaaQtugLsHaCTuxhRL9t2bFmtTIsoUfMl1uHWpOWMdv2LeGEcDznZp633gZh6SDmrqLq2Bp2iOVBew==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/parser": "^7.18.9",
         "@babel/traverse": "^7.18.9",
@@ -1575,7 +1574,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1592,7 +1590,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1601,13 +1598,12 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils": {
-      "version": "42.0.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-42.0.0.tgz",
-      "integrity": "sha512-zfzTnKN6uZmRK+4uXgVY5eWajxeXGirMK2Yac8HsQVankTfQkhA1UZCeJMFOWJIU3SUqbEVTL9Rg5XvieZjc7Q==",
+      "version": "43.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-dev-utils/-/ckeditor5-dev-utils-43.1.0.tgz",
+      "integrity": "sha512-EM1zg0vWcFSkxbwOYV6YE6nPoBphfEHtRKzgk86ex9XbxoQvq8HdDvC0dkCSAfgX0oUrFxjLonQBJUTgCoD3YQ==",
       "dev": true,
-      "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@ckeditor/ckeditor5-dev-translations": "^42.0.0",
+        "@ckeditor/ckeditor5-dev-translations": "^43.1.0",
         "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-spinners": "^2.6.1",
@@ -1615,15 +1611,16 @@
         "cssnano": "^6.0.3",
         "del": "^5.0.0",
         "esbuild-loader": "~3.0.1",
-        "fs-extra": "^9.1.0",
+        "fs-extra": "^11.2.0",
         "is-interactive": "^1.0.0",
         "javascript-stringify": "^1.6.0",
         "mini-css-extract-plugin": "^2.4.2",
+        "mocha": "^7.1.2",
         "postcss": "^8.4.12",
         "postcss-import": "^14.1.0",
         "postcss-loader": "^4.3.0",
         "postcss-mixins": "^9.0.2",
-        "postcss-nesting": "^10.1.4",
+        "postcss-nesting": "^13.0.0",
         "raw-loader": "^4.0.1",
         "shelljs": "^0.8.1",
         "style-loader": "^2.0.0",
@@ -1633,22 +1630,6 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=5.7.1"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-dev-utils/node_modules/@csstools/selector-specificity": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
-      "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-      "dev": true,
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^6.0.10"
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils/node_modules/chalk": {
@@ -1708,6 +1689,20 @@
         "webpack": "^4.27.0 || ^5.0.0"
       }
     },
+    "node_modules/@ckeditor/ckeditor5-dev-utils/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/@ckeditor/ckeditor5-dev-utils/node_modules/postcss-loader": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.3.0.tgz",
@@ -1730,26 +1725,6 @@
       "peerDependencies": {
         "postcss": "^7.0.0 || ^8.0.1",
         "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@ckeditor/ckeditor5-dev-utils/node_modules/postcss-nesting": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.2.0.tgz",
-      "integrity": "sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/selector-specificity": "^2.0.0",
-        "postcss-selector-parser": "^6.0.10"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-utils/node_modules/schema-utils": {
@@ -3220,50 +3195,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@csstools/selector-resolve-nested": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
-      "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^6.0.13"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-      "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "engines": {
-        "node": "^14 || ^16 || >=18"
-      },
-      "peerDependencies": {
-        "postcss-selector-parser": "^6.0.13"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -3708,19 +3639,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fullhuman/postcss-purgecss": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-6.0.0.tgz",
-      "integrity": "sha512-sUvk5PV7O5xvTJcxDYrQ00xlKtSxivvJdZrwgxE8F1GmNMs7w9U+dSbr83N/qEs9b+f+6QsZKXDs0k8nMjBIqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "purgecss": "^6.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -3780,9 +3698,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7045,9 +6963,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8963,12 +8881,12 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -9203,9 +9121,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
-      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dev": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -9217,9 +9135,6 @@
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -9244,9 +9159,9 @@
       "dev": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -11069,15 +10984,12 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
-      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11944,13 +11856,10 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/magic-string": {
       "version": "0.30.10",
@@ -14965,9 +14874,9 @@
       }
     },
     "node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true
     },
     "node_modules/parent-module": {
@@ -15665,9 +15574,9 @@
       }
     },
     "node_modules/postcss-nesting": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.5.tgz",
-      "integrity": "sha512-N1NgI1PDCiAGWPTYrwqm8wpjv0bgDmkYHH72pNsqTCv9CObxjxftdYu6AKtGN+pnJa7FQjMm3v4sp8QJbFsYdQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
       "dev": true,
       "funding": [
         {
@@ -15680,15 +15589,72 @@
         }
       ],
       "dependencies": {
-        "@csstools/selector-resolve-nested": "^1.1.0",
-        "@csstools/selector-specificity": "^3.1.1",
-        "postcss-selector-parser": "^6.1.0"
+        "@csstools/selector-resolve-nested": "^3.1.0",
+        "@csstools/selector-specificity": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0"
       },
       "engines": {
-        "node": "^14 || ^16 || >=18"
+        "node": ">=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-nesting/node_modules/@csstools/selector-resolve-nested": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/postcss-nesting/node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss-normalize-charset": {
@@ -16156,7 +16122,6 @@
       "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-6.0.0.tgz",
       "integrity": "sha512-s3EBxg5RSWmpqd0KGzNqPiaBbWDz1/As+2MzoYVGMqgDqRTLBhJW6sywfTBek7OwNfoS/6pS0xdtvChNhFj2cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0",
         "glob": "^10.3.10",
@@ -16172,7 +16137,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -21473,9 +21437,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
         "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
         "@ckeditor/ckeditor5-package-tools": "^2.0.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
+        "ckeditor5": "^46.0.0",
         "concurrently": "^8.0.1",
         "css-loader": "^6.7.3",
         "eslint": "^8.40.0",
@@ -456,184 +456,184 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-LDuBb7DCEXsqCbePTda3yVZjGARbkZE1j+EQylu0zXK9vh/hY7W2P6ur6kTtNHz+A358PQ+3Vt1zLVap7UfpZA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-46.0.0.tgz",
+      "integrity": "sha512-Y5OrOyHHgnjA9ferph822U9eJdWqIFbPoRpUTcs/kXWKmQBCvAqPOoGJGAz6O9TCZoGUqjK71eVKV0jSnSo22A==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-upload": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-alignment": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-N8289hF3fsgN/TdEKacnMvNnuau9oqlCcONPle4MiQt/lmI3t+C8WucfAmWUExIQAmYSpARhhvdhd7AjPEcLWg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-46.0.0.tgz",
+      "integrity": "sha512-GNyqLCASALv9hygMfj0lvsl2WAMbOLNcezjjlapYYiZDJSWrxWkYI8Sl+GojjWYyIovwBaGHwJM1IDYKB3mMgw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-yENBSRZ2rjy4FQSyOd6dm7AGfgQuTrHW6Kfnb3c6rUplt94M5HMqcwzozvxXa2FGTrynqV/ejzmeVTgo9hS99w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-46.0.0.tgz",
+      "integrity": "sha512-/PU0QlSKHTemYzELG1cQWn7GQ2AYKb3+pSvM3sTgxYkel00KZcmmh0Nl18nyJrlKqn7xKAqEg8XwjsF17I/fJA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-heading": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autosave": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-MV3GXIYNnZKxT0S0Vq69Li085cnTZPUPc6PtBO9848Y2rqjllUP3poIcRm4FCFzCVXkx9nFAtqEYH0aNEUOQ0g==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-46.0.0.tgz",
+      "integrity": "sha512-xIaLvCg6ijac41UyPMIfBvS1Gc1u9Y4OcvGln3GCskdFVyjNhHOe4p8yaTavwJ78Dc+59zDIP0rGV8AYWFhyYA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-cB8W/QpFZTdLVD0vh9jNJQJ5d8qwbdRvDuf3ikKj2vwP7yC7s52/OtfAbNB+6ckHRS/pRVug61eT/DFfyZbK7w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-46.0.0.tgz",
+      "integrity": "sha512-i56SO1n0Xuclhel4Ol362khimK9NQFv4NEcnP058b7JK7JXVDZlyyNHh+J8nTALWokmoLPvj823/2F4yKC8oRQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-oV/TuoF2uWX/iUbdKMZzuCOuv0dPGpuAyoligAPzRfW/KBc4iLYClZ02fn9J2d0x4PylEO79tKaIct8JFd/OkQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-46.0.0.tgz",
+      "integrity": "sha512-ASZM3p0wzg2Q4OMsEFhyyi3mN8EUl02LhOxZ41eKa1H2qtAUi+aIFEYNf69raWZ2tqzLfm0z2wTNROzPa3KCJw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-bookmark": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-rI6GAuiW9+K1fc2dpMsBIN/aW2cJ+0DxaA8gbJlefvwqFHM0GMrYXWDBwOs93JO3N7Ygxcpz6qWdrZfJyggFSg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-46.0.0.tgz",
+      "integrity": "sha512-E52IERdDfNKuagMUkFju6ScFqDIDpXYlLhOmOLv7C/Xh8vKJtyufjjDl/OkhBdMa6gaaHug4a9F7OfCtE+P/Lw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-link": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-link": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-Z+7JH//ukqFEP8UFz4BCxyIXGoUg0IcJlBZsxfi329jbvXCZH/vvUfGHtplF7+yhM4ngr7RoJH1fg5hdBzMgnA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-46.0.0.tgz",
+      "integrity": "sha512-3RWEx+H7+RKlblI579w8AnlDO3JeRFHmNxh2XolSGohy1bqTttATi5WZVVmGK6quIgFss4VmRpuzZYPpiciuIQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-cloud-services": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-image": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-upload": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
         "blurhash": "2.0.5",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-f/XuuVZkuFu0KEEwSvsaQcXaUC04MbgVYNNfGMy9bvOdZS1Wrj6tD/6btPKYJpO8qSNSfsj/uOT4cC8brqtgvA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-46.0.0.tgz",
+      "integrity": "sha512-g7bhFrrlEUi/QbRkGbNRKeeZCrXU7DkLkGsMBypb0m/7hFF0M3XivXNxh9MxrBjIbCyLjnCPXZVL3dLcapHUww==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-image": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-BSG8EZR9+mmY0MaE/laTlMEyM2s3HWXdcxPzRr9XSuTDKMPu6I6T0MHxNdZGdYTTM6bq4gtDhZVLt6sg3CIjtQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-46.0.0.tgz",
+      "integrity": "sha512-FNXyYk8lZKCdpOOql8rTGnTyW6eRo07i4jTSb0sCOOc/x3iAfhyw0ckHI11hi7U3cYE0fOf8WZvp2fn0NfsPVg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-2PyvFNtY8/NuQ6uTKoBXwTYPeMj9mBoJKoLioDwxWH39Tqo83RPQjuB8/+0V7YsJU5VvpMhRBLPZR07Rji5eUA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-46.0.0.tgz",
+      "integrity": "sha512-ai1OjKmoWmBK/RY5jUXVFAX92szMrK/UcVcu1QHwYBoBNqxoQajsLyzBd+QUg3Z3AdQCpLEJqabgsfizMyrpiA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-code-block": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-X3FdRVzO1m4VtlHh6N6utqd1WdQwObxBz9wnr5tNGpdTyzXF2Kzn5veXA6kCL1/mceZR7IvBU9qOu8ywlLtspA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-46.0.0.tgz",
+      "integrity": "sha512-9rJqjpW/RY/kKCYEWMchTaTuGyMnUHspteBumtFOnwJS6PVaA1uJU5FOAPSFevZx9KzJBoXbehxtZWmUjImLMQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-qKaIsCjdqc1NTtzNuY/p3uXNSCkujS4Ol57D2IQNCWfJfejCJIS5Yy9EwroOtAe/5PixZ3Oh2DtyrAe5JIxNRA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-46.0.0.tgz",
+      "integrity": "sha512-Mm5bZVE6i2vcmwaCPvXgNGsVZwgQfb7DZhphWMZD7z4yfCJjqiJ+3ph6ZHtByHLcbUhq1Z8mn8Q+23Y/BVXfhg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-watchdog": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-watchdog": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-dev-build-tools": {
@@ -1803,411 +1803,673 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-GbN90wSE6o6rqvg8uivy10iunLRGbB3TLi/8XxwAB1LG3Sc8QhdHNQwngX1/3GPm5OvJgiTb8FI2VgfpWjoKGw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-46.0.0.tgz",
+      "integrity": "sha512-y9rnIlbQRSe3FRdsoAaL0zpW6jlYPxIpCGT28WdWAF3kLwMp/41oKz6ggjbgzAafobUsbPdjpOzoLEDb8RyMcw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-cloud-services": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-cloud-services": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-upload": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-balloon": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-BZL5Ra7DeTrCN8O2CGqsCEx1J/qpwAgFf5B9kYaurK74Vv/sV0xFsTsDPph9UWGJLX128QK8GWPulRiDo1DXwA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-46.0.0.tgz",
+      "integrity": "sha512-mDkeX4Lu9NG8gWW1hWPQvR2ZJ7JqKXBfkxRgI7D3PrwrfDyzT2XllfQ31ZjvdUwyUUWyJjIV5AkjsjwWerZHdQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-eJPI4ywjn50VMRBDGD3eZe11kX1wbRojVU4bDOkVkCL0Xv1gK+fsgBvII74mYUQBBJB+J32Ktd+AA2s9ogya+w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-46.0.0.tgz",
+      "integrity": "sha512-o0JLR+7KEydjEuHepkaWbi1VGzocxRik7/LiN60jvzeue48YF3ELtD1czRa5eebuAzh3FSL2r3hfbqpagxGlBg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-imxu8XUSJ8lM24I3V8c4ME8bKFTRN0H5yIOU3O1Okch5WuSfieyWwjfn6wyl6mLPThH0JjB9Z/3qluUyt93pnw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-46.0.0.tgz",
+      "integrity": "sha512-HkCfauugtLQxD87A4HcFq2nMxnYq9yngh5JZTPygDSDigRMjNtbdk4PVqMt7p96yw6epJs1HVIZDlFqLljJfLw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-inline": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-itQOKznXoGad7lhGCLCpAz9z3r/cMGQOBpfBP8Ug3Dk1QjqsvLlXtGV5brI7NJ5qi7oMKBRTceN9x7Q22psvkw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-46.0.0.tgz",
+      "integrity": "sha512-m4C6wFkEU16wLdwu2IkTutz+M0u72yqbngMVM95TJ0FNhNQf3T/TVdhjVQxMDlw7Ep+2X3vUDJXMpDQXLNoy1Q==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-IVun5YGbC4wh2SxSaxovJCSj7ehsCTHfu8jzojb8tCULjUNo4PTjflil5zLP7hNcgI/hhjkm0lWNQSnBSYUFcw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-46.0.0.tgz",
+      "integrity": "sha512-WHCibqvsEBVZ0KqlCycqL+7S/5xXt+c4vuLlrKA6hYkF8YQXnxtxIVIWUZp6fEZi0+b75Eke3dOEK4wTY/tDbA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-emoji": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-YEodQZFyCHx682D5I07qSRdKcuBRZo0SSn9Anq06tMW/64CpOnSL8d5oNqqTLXaOmYJR50a/WtccMTdcIi1pyw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-emoji/-/ckeditor5-emoji-46.0.0.tgz",
+      "integrity": "sha512-XCvkdcujJQeQbYMR6vGzZeOt11+9Q+BbzPh45BAytqzrWN4ngOpJX+BS6ORiZK4f9EsWPgF3kJgJiLVEJhovvw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-mention": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-mention": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5",
         "fuzzysort": "3.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-5Z/3l1Q/QBBUV+POPBsCkL0VLIiJ3jAg+n487uH5BKOkT84wApVtJxsvJaeNJR10Waar543htIMR9ZRhbFNgPA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-46.0.0.tgz",
+      "integrity": "sha512-kuTPDygXaZkILp2A002zDWEZH1gHd6Pw5UfgF+S9f9wEgA0vPLYi/qbeqLkM6D95JQyAfXYPuEkXq6fZdtoZYQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-Y4DcC48ujzoWKw3RM8sySV0IwX1PTlIJXo9rIjbH4qGQHGabmbtbF2nfYEWyK1Fvs8yFrq22Zs9cwF9PQ2iuRA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-46.0.0.tgz",
+      "integrity": "sha512-SAGbScUrB1nazw7dXaGuT/S02bmYvnz/AMRxDkjRAXPqCNE6AUgdCr6dDmXREigQjsR01jvhvx1PAZwUgiC8IQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-v4TMSui3lPS6G5si7Nw3w5id8ti6B1ik46vQ9A4GVASsIjnLfKUgxkOAkIk3yGjZIVdwGy+XGmiZi7Py1BDI4w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-46.0.0.tgz",
+      "integrity": "sha512-3YuRFelc0f0oerzdrcDvSsMkKDATAB/Z219mjqize0N2RwUA17CCMCbFnGDWZYRekglRQYLTvxd8LCTCmEjQFA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-select-all": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-select-all": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-undo": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-find-and-replace": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-lM+2eXHazwwWaCeqhWT3uwkqmmXL8VLB7QqgKNyiRe1Dwk4SBmVBpESkjEZhemT2v1F/GVgj/XljKD1pla/Htw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-46.0.0.tgz",
+      "integrity": "sha512-qGw1rOyGVRKQZR7ogNs0XxUb78SkB0xie3LFWZduFAGOaDhC7+DMx91UuO2+lbEaqgGtg1gffNm4Rce//2WdbA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-font": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-hJTypKoD/xgQh+8JKgK2JDHiBbTavK5/OQj1c5R9f1EUBhgNkUtZnS13X2EiuHv6N8zilTJsl704LVmO2Mex8Q==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-46.0.0.tgz",
+      "integrity": "sha512-Eynyqqre6p+X5ZxlojOfbWuUh8dZdjSnm+8m/7lEOwh8rgzEA5QJ4k91x5BFCYT/yMCesvKTv8H39qIjs/J0Qg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-fullscreen": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-9y6BVHUPyZCSzMOiWwFKLOGOI343x0dGKHJxdfYHDVr9JCvSDLqEtknc2iZnRLhYRTEu2Bj8efkZ/Kl7m1wMWw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-fullscreen/-/ckeditor5-fullscreen-46.0.0.tgz",
+      "integrity": "sha512-vus25ec9AyGOVcy9ghUTILz8LLctW7dDP2GhUreCX1FEouue8UgvvrfYYLwim1tI7b1deRcg1zIAENHVhjNLiw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-classic": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-editor-classic": "46.0.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-/PVdUOLTeXRN4ByI42immX7yDVVqTPg2SdGacAXgEyBJb5XvZ8j84g9dmRXsIQxTd3xk3m7Hul1S7/dKro0ewQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-46.0.0.tgz",
+      "integrity": "sha512-fIrmsH4xh3d/QpunSZR3RPR+jybEXBibYwd8EF3ClcpmhhtMRul7BponRVb70a4A4bE+35Pq3Dj+HVV1bn6pIg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-paragraph": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-paragraph": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-highlight": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-6T6AIhAEedMdfvo2g55qKMbJTa4Y+LDp6QOENriyMJrpUHdhU0DEaLieLIHECQBEbZG7aAgBPJHCU1JiQsqVxw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-46.0.0.tgz",
+      "integrity": "sha512-F2jChM/83tcogE3QrxzQJtbCCLhzZY+izpXhiYLO9myfm0guOXITggTbl1LiJ1jdV9iEpq81Lq72/m5mZl5kVw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-horizontal-line": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-OC4yG2RMSLSPNXorY9JbBCBrazWzbLxLiIwNVgtY5c6qOzEkbTVIztYbNXTExlpZFDijeHSOSHKKCQ5CwrO86w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-46.0.0.tgz",
+      "integrity": "sha512-5JAYD3nohuqgjPf757XFqi5JWGLkf+5s8SBKFL7b5r6g0WQT0zm7yIxPQGhy0N2eFBFhPW/cdWPa3WhUJYVCmw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-embed": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-KJ0ZxymcJ6oLyvymMiq2W9bxI0ndhKkGkHjbyL8aXx3Hzm/UHKEycok76+Uc++iaR2PF0/NbcYgJN17hIc7M0w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-46.0.0.tgz",
+      "integrity": "sha512-jHuvg+hIDyjq1zqNoMbR1sbiDBdmd4pZzG5CYcUW2l1DblFzjDq1RUnETHpS+YM0tu4QYYLiMhd9OE4s+bO9eA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-html-support": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-vXwr5WxBZP3+dYifYPtWue/4BS/FercP+VzuUUq6pvo+zmhzAnOrvFbeJy+SAiEB6ke4pHNtcY4HIl4eFlVSZQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-46.0.0.tgz",
+      "integrity": "sha512-w+CvJ6fBzxXRJ978urZsOKfLXRINzUsfUr4XqUcU0Y9RRXIuyQa/XSRqgAZY2Wrl0t56P+AnolKWJDHx6yiVlQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-remove-format": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-table": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-heading": "46.0.0",
+        "@ckeditor/ckeditor5-image": "46.0.0",
+        "@ckeditor/ckeditor5-list": "46.0.0",
+        "@ckeditor/ckeditor5-remove-format": "46.0.0",
+        "@ckeditor/ckeditor5-table": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-icons": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-lXxrePETNsRIx4SFnlWwVryHoBnf86bXlImT/IuCGiGRqpaNDjnSX1cOLR+Xr0sy2ZbMs9//a4ic658ie2dCNQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-icons/-/ckeditor5-icons-46.0.0.tgz",
+      "integrity": "sha512-WjE4DWF8tnUgFWmvVZswTQnqpWnwSGIZaG1aq11iHFvzK20O7IzJmKzxS6QxOYFeK+I8+sLzbJEDQeZerZb3Kg==",
       "dev": true
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-3voUJ+32K+sN++fQor7VUgthtQbh2BDhsH8cLD7NJMus/mF1O5UWwyIXy/MCOrl6rnc7c4wwoa/BbVP63Q+LuQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-46.0.0.tgz",
+      "integrity": "sha512-7NbZB1IrH+2/TJQ07RPqf/o+Qg2PFgtOl0lT8/0nSqCUVbaA5qb2hxoSPB+NGJGeSFRlJEjf0QHMSv6xA2wR8A==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-undo": "46.0.0",
+        "@ckeditor/ckeditor5-upload": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-pfuM9jOvAjcMSy+984nlrjPwEc6y2nOzXu685NcCwzROxIhnl4taLmN15QNSucM9WWVQtDd3tEFTjSPWL+05gw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-46.0.0.tgz",
+      "integrity": "sha512-DGAHxA5NIe4jQ9mnoTpx6EpXKaHFSbqReZBQfZQakW3ypUOjRbpwrQOIEVtRSADaxRM37KcO6oS8duthqqwNDw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-heading": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-list": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-language": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-XzyA4qfy07I4+NfrShmzZT9of9n6uwF0/YhE3cUaZLcqK2NfjeJfT8zVa7z3WLf9yrNuflK9c7kGdLRoD3cbsQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-46.0.0.tgz",
+      "integrity": "sha512-REricrlKECtJy9E7F6uP+xcYweJU/eCiD5+pHCTosw9/x7XdxwLydwtUosmG9fgvZDeWBEH8SWc9RFCDscPcNQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-qrDNm1jX0npnQ8CwiPcdfy1uVVIdeyVGs2D8xgKhJDoLw1ldkd/NM1dYuXwIkfEERNOxgt1FnCGcZcH/Jh+0TA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-46.0.0.tgz",
+      "integrity": "sha512-R3cCGqgO7FOQJu69yubdoBGaRJ/mK1AB5J4NQXOslNg8us5QIbbL8ZPPbmAY3QtK7w59rJ4eeHJbtAhy28RmWA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-image": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-8UihRjJTCgT41o8Dx6xDa+Xo7k9McoC5mCKP9tz4r3/boX9mPd9WoRZgyJUqND0WsMyCXCVGBcrdh0iJI/iEng==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-46.0.0.tgz",
+      "integrity": "sha512-TsEUVFFT/MsJ8JLzE4YAmDDB9kImOBx7+pATN5jQJzKB2pgAoEihTytnWni45nEcXOKj8rOf3CvXTl5rVJfl2Q==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-font": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-geO9oeEpw6uqsanfLdbcCIof25V50GLW4U95faITkE54HGzUw6vEtK5nuji/R+LeCpVAW3dY4rrS3Nfkr8mnig==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-46.0.0.tgz",
+      "integrity": "sha512-uDHTS+VrmUY/bZWDQv/9nOOSMnfLOymAmvQ/oTNPlIZQXxprDU1cH221TxOZpvE0u1SHC3Spomt38Ea6yqzGZw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@types/marked": "4.3.2",
-        "@types/turndown": "5.0.5",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "marked": "4.0.12",
-        "turndown": "7.2.0",
-        "turndown-plugin-gfm": "1.0.2"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@types/hast": "3.0.4",
+        "ckeditor5": "46.0.0",
+        "hast-util-from-dom": "5.0.1",
+        "hast-util-to-html": "9.0.5",
+        "hast-util-to-mdast": "10.1.2",
+        "hastscript": "9.0.1",
+        "rehype-dom-parse": "5.0.2",
+        "rehype-dom-stringify": "4.0.2",
+        "rehype-remark": "10.0.1",
+        "remark-breaks": "4.0.0",
+        "remark-gfm": "4.0.1",
+        "remark-parse": "11.0.0",
+        "remark-rehype": "11.1.2",
+        "remark-stringify": "11.0.0",
+        "unified": "11.0.5",
+        "unist-util-visit": "5.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-BA+wdcH0GYYS4sz7YqoOhlTz9FeDuZntKAefrpqLr5HCoyzU8DDruLnULtWVb8ZsB3X8OCBq1TsIff5AOTLg4Q==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-46.0.0.tgz",
+      "integrity": "sha512-ZC8JbaWAxGaC7bANYc7ADOKZtHJFHNsftwKWt0xb2mmqox8BpJlEo6o4LYakXcPBI/JgnXawwukDia2KR8Bz+g==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-undo": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-mention": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-Z6V6m2qTwIgLi8KTz6ZyD6Fhs2etSQZ1JODqOym3AB7OBFxPB5P0z+bTVjT44SBM80ar44OAZhD+GwEOzKdKSg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-46.0.0.tgz",
+      "integrity": "sha512-BWwzitc6UUR+vmBf5Hvb1MNmFsYl5k59YT/dKXl0TIeKPJgygdRTFv7EN95wgA1ROpUXRwjCDCfYP5uuaLfjJQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-minimap": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-Y/AJiOuaq6AAnz2jDP8SbLug5lkIOtnkuooWLjOG9Rfv7m4PRx/2H9ZEpMeI1rmUKBIGRywKrPqMBaAnaKaSLw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-46.0.0.tgz",
+      "integrity": "sha512-HiMv+fb9VBmtxVbsPhiDhfn2g2bLP3QpVXT4gmqtYEZoFV/02JvIqeweKDXtx/hrY4qXqklbKNECrJLEAz9Ssw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-package-tools": {
@@ -2639,195 +2901,195 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-page-break": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-6ZhETn10kL8wWY8PrsN00p6WsZ6Ea5bKjNCLnyTmRoskkr0krcrA/PirRdl/lkqzNOhSEhP58GAplwLpSISH6Q==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-46.0.0.tgz",
+      "integrity": "sha512-zhgqdS9CLdJ46PTsMogudKtxyN2SW+aCEFjvXff56j51kvfY9shUfk6I0O8+ChmslWy8v7nM4QAQVTDJC/vSEw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-sVyb2KqXBO/Kxxws9wWEM7aKmjj0Y+zrc+qh4jfFtAfu2JfoieERogt2SeQAVHeEqxTdP6xXnUX6ME4o4pSmxw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-46.0.0.tgz",
+      "integrity": "sha512-3XCJTzFBGv1G6ZS2zQ8QVfX6waBXW08cvFi7F6hhK44OZYllTgW0l9jpR1TnmcC3VokNa4LQrC1fn/J5Hk8fBQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-njuV+RVR7nZHwqUy9H75sNgWhbHxfhYsTIZvgf+SVTiEBHJRHg9eahaDal0RjcvEJkT9Wib36uqJheYa3NjRBg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-46.0.0.tgz",
+      "integrity": "sha512-8GaHLbcuG26xPiGtp25yoYqB0wy+0IgDZqSW2m6rM3DsMHrFWilufwArp/9wExTBjeKgdbsgv6BP0RFEA1oXcg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-remove-format": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-iraCnKlUMmmOtH5Tekkb6jBnNNIP8gkZexOHMqfN6Mpr/RQ51+Cf+wjXyQ+R/zkA7h5LieETwgP/n0uG0a8lOg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-46.0.0.tgz",
+      "integrity": "sha512-bOSzTlhTk8TAvSt7C+yNrS531y/D2ghoFhyexhBb2JU+TAeNXkuyuTSxFc9luWIZf2AKvWe4hU3yyVDIlXT9Bg==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-restricted-editing": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-YkT4clGKBOP5922iILP7MaDvIOpCGeQwX6c7G8asRchsz9bGeiJ/9q7GyDZWR9WqofocpsmVJKFes+UdFAWctw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-46.0.0.tgz",
+      "integrity": "sha512-euhQ57RfJFJzRP9SseV4sqWsXY9WRQobCaiW1ENxnwEa4FxmnDiLElR6xZ9jimrG5bN3ldbedjJ79mhKp9VMhA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-zRFWNP2peluVyFYt6ndpfC46hjI5eEiBwVjw+L6Nh6VpfMiToX+h4NpxONnO1kHiVKfaNVJ395vXgml9noYarA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-46.0.0.tgz",
+      "integrity": "sha512-6SvSkYuwZRJuTy/HwQUGh3HpkxkCkEq8Yfew6YWuwulRUgKwMrD4F9R6ZUqDCornTpP+o6p9UrseSFn/3sgxwQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-show-blocks": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-YOTtfOZ68gcSl9HSOXuz3jjyslIipK20SuBbyukGoGU0onMoDb0ALZxLeQtHAJ76GXtTbhVzkg9i9sNBVu6P5w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-46.0.0.tgz",
+      "integrity": "sha512-hhOANTwo6XC1Y59/O8q+XAh+dqokhMov6/HLeuZ0uxVCuryDQxXh+C1lU6rjFG9EKW0zUoQPViLkOAbx/Nm4xQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-source-editing": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-6a7LoIZ9/5xL4FC0TSqj5iQBI1WXrNg0mJTrBeUKBo0apsoKY5VhnOZ330rRnzSdxMBw/DNnHw0BfpWoJOQ9Kw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-46.0.0.tgz",
+      "integrity": "sha512-TRIgm1vjSerGfuiOg50/+WNXzDYUonjZLsxvFP3c9EOpTs8vqXjdQP/VeyK4PG3DgbablMsZOZhSi9ci0IO3xQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-theme-lark": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-theme-lark": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-special-characters": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-mOZx+/50mexVEMMoBEBt0O6SSEsuDmPF7so6ID8xVj7mL9h+kPt9M06ShjwSQMNB9BYsgoKKNedQ/s/MDnEGVg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-46.0.0.tgz",
+      "integrity": "sha512-tfjKoavd6rguOE3bzLl65PWJQJsWtAJCZVvW3B6TrbeT3oEqJ1UhBnnA46LgwvXM5tT94b7xCK2AmcjyQ5eG0A==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-style": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-D2M60e/ODk2eknKOD+Vc87JENTmBIG2vsIWT9/xZYE4k09DOfTulIytWrcDH1SzZm+4aq8OKe2vYgC3xZcX3GQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-46.0.0.tgz",
+      "integrity": "sha512-Cm8jHegh4UG+1309qbs/hf7aIYTyqp4/zbBciW8Mcdrct8d2eeIigWPt54sw2PWz3v5ZsUquH4Y4JupiEXsOOw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-html-support": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-table": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-html-support": "46.0.0",
+        "@ckeditor/ckeditor5-list": "46.0.0",
+        "@ckeditor/ckeditor5-table": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-vdkrEvXdKjzFrq47g6q2gb1LeJON5Nco+9r+6gEhqVjXhxi0AgVMDL+Q4DgKZpsEJwr+YYmzduBMVvVAwgvHMg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-46.0.0.tgz",
+      "integrity": "sha512-N51XBgCWsxrjMJaw9DNuCF9oYhdQgSRhtDsEhY8Q9+VYdtfSxEcjtLpzlUT2/GIwrZKWeFWuJeB3sba/jdfP1w==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-theme-lark": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-Vjva3bXNQ1vVz6AzB0GoOUz5uI9sRspWaxaIbCa0yVdz5geCG1poSbyqmoPDHmhkfX6bA1rywZLOfnCb9lXUOQ==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-46.0.0.tgz",
+      "integrity": "sha512-gaztcvUQ6KAbNTB1efkciEWwesJIp9CjIM91nOBj72eR5/xZKM+aTbLdiciVFSgB1Ma1qCU3DvQ1vafACO93qQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-ui": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-Jvtrw5/H1FzuG+qOGHcFjqk1b5b8AeZdycEZAIDuk+bO9sVoMRc+K6xaOf4rAYz+X6ReW1cR1IX0hxJlsDiziA==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-46.0.0.tgz",
+      "integrity": "sha512-xeFrXEpzo9T/bLaIwHtYDSSPb5KYA2eiYPVWxivw3VEs6gDfHhRz7EZEZ9OhnjNBQYhiyLgKaX+3di72sqrbhA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-swGcmpddoSD8TTRXPIzCr9g+r+ML3UyHZvHHf2oNGariC4ReH6yyHxCloO3kYWw1/vYY9pQUM22DkpH/0Grp/w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-46.0.0.tgz",
+      "integrity": "sha512-VMdUOK42l+b/rHUctXv0WOMbvcqWXM8kglxZ1paAzWBWhhy1cp2Q6VW21w23VSmmwNA110xPKTcKlkC09bniDA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
         "@types/color-convert": "2.0.4",
         "color-convert": "3.1.0",
         "color-parse": "2.0.2",
-        "es-toolkit": "1.38.0",
+        "es-toolkit": "1.39.5",
         "vanilla-colorful": "0.7.2"
       }
     },
@@ -2853,78 +3115,78 @@
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-SP56siPhg9f/RgoXKsa6Po+mTU/Mvrlnwn0U2Wc/GpOmOuJp1UGeXZcySKctBfliH10lz1NKf1bVqKFG4Rt67w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-46.0.0.tgz",
+      "integrity": "sha512-MoLU8c/ip7KVByKZT8fVXSP7ZzxwXu4Rxk/T91rHcxR2BLa93fyS3M9v6oXmww9fI9enGVPw2LD+yESXYJMOiQ==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-iEcdCX4H9oI5QPxwUIaOJttkzHwPF8kLj5PzVT2yiSVioCK+HeVxxMP4Cdx1HECl9SVazdp2kJ4orruel82dHw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-46.0.0.tgz",
+      "integrity": "sha512-GPRctyLpktYgV00C71R31leUM7rZchEqdvGK+EJfmx8qWkzuKSXLN8HJ9rhjgFf8D49eQm506sH5lek9+HZA0w==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-OBX4oeWumSl5y+MG18PH8ZPc2LuRtztJWP80vn98NU8e0fc0RVqy0w1OnBKqLuJmBXSo1qO+G9MpoVHQ+zRB3Q==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-46.0.0.tgz",
+      "integrity": "sha512-wql+hSp29EMMhQlj0oXHiOOzD4ZTvRrI7801WtFjfiSldmIJAyIiF4zLFiRoB5+pGbt+AQB76VAdqFjz43AkuA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-watchdog": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-us4XIM91JXl/OqfnJTHDrNpTyk9zGIEPDXrnEkduCMukCwKXPv42Gy62gTcGXGqzRdTDe8cZ+8hhA0ytxU3B3w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-46.0.0.tgz",
+      "integrity": "sha512-p6lNeUsuWkJ9lJ/59TkCOUrOhUxcB2NGm3sGsG3qHSB/I6W6jjW3r7ZZah/z3Ysy0ImkHLQX0WlFDlw7E6EnSw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-2LqAMcso8bcVcI+frPd0lX8VbLOwt/wiOZIw27lDd2/u/QIWmScCDm1D0IvF+PIPyMReYnmbvRpXXuTZ3Kkvmw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-46.0.0.tgz",
+      "integrity": "sha512-NhTtCkkZQNzKHPtUvN5ukOUfwI3rop0Zdo9QxfKFcrSc5B7a9+YLX70lyPzp6loUypy9N9XP4qvvjBUXg64UMw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@ckeditor/ckeditor5-word-count": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-UPnQZqDIt3JXLK9xSj4H1117OeB3Wm2HiXPG3n091amcRHcbUzW/MAB8J9qgkKI73bIsJ+0Ch8u5tUC0qke7sg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-46.0.0.tgz",
+      "integrity": "sha512-wCoQm66jgkFcW8w2acqkUbTzxFt9dkFilU+cMgLOrxBdYarG4T9Xdp2bk6CQyVYf3s+be7N+QGwJGsIyhWT+Gw==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "ckeditor5": "0.0.0-nightly-20250624.0",
-        "es-toolkit": "1.38.0"
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "ckeditor5": "46.0.0",
+        "es-toolkit": "1.39.5"
       }
     },
     "node_modules/@colors/colors": {
@@ -3638,12 +3900,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "dev": true
-    },
-    "node_modules/@mixmark-io/domino": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
-      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4535,6 +4791,15 @@
         "cssnano": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -4595,6 +4860,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -4614,12 +4888,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
-    "node_modules/@types/marked": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
-      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
       "dev": true
     },
     "node_modules/@types/mdast": {
@@ -4647,6 +4915,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -4741,12 +5015,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/turndown": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.5.tgz",
-      "integrity": "sha512-TL2IgGgc7B5j78rIccBtlYAnkuv8nUQqhQc+DSYV5j9Be9XOcm/SKOVRuA47xAVI3680Tk9B1d8flK2GWT2+4w==",
-      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.10",
@@ -6061,6 +6329,16 @@
         }
       ]
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
@@ -6095,6 +6373,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "dev": true,
       "funding": {
         "type": "github",
@@ -6195,72 +6483,72 @@
       }
     },
     "node_modules/ckeditor5": {
-      "version": "0.0.0-nightly-20250624.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-0.0.0-nightly-20250624.0.tgz",
-      "integrity": "sha512-uq3ZL7vSppEF4uTQwV12opfmSlUA96MiLxogsbAGC35jCDccL0t+ymqn6gYfZKtUmUdwP6WxdH7qohrnZcLakw==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-46.0.0.tgz",
+      "integrity": "sha512-xOvTcZqeVCsEM6hp9kHtTAAS6Elie/WZ/RA3FYZjR2251CI66vNOb0GWU+c0ufr2Ha/FuXRdgV4nSpIv3JLvaA==",
       "dev": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-alignment": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-autoformat": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-autosave": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-basic-styles": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-block-quote": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-bookmark": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ckbox": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ckfinder": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-clipboard": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-cloud-services": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-code-block": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-core": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-easy-image": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-balloon": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-classic": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-decoupled": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-inline": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-editor-multi-root": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-emoji": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-engine": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-enter": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-essentials": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-find-and-replace": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-font": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-fullscreen": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-heading": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-highlight": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-horizontal-line": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-html-embed": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-html-support": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-icons": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-image": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-indent": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-language": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-link": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-list": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-markdown-gfm": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-media-embed": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-mention": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-minimap": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-page-break": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-paragraph": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-paste-from-office": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-remove-format": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-restricted-editing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-select-all": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-show-blocks": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-source-editing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-special-characters": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-style": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-table": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-theme-lark": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-typing": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-ui": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-undo": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-upload": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-utils": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-watchdog": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-widget": "0.0.0-nightly-20250624.0",
-        "@ckeditor/ckeditor5-word-count": "0.0.0-nightly-20250624.0"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "46.0.0",
+        "@ckeditor/ckeditor5-alignment": "46.0.0",
+        "@ckeditor/ckeditor5-autoformat": "46.0.0",
+        "@ckeditor/ckeditor5-autosave": "46.0.0",
+        "@ckeditor/ckeditor5-basic-styles": "46.0.0",
+        "@ckeditor/ckeditor5-block-quote": "46.0.0",
+        "@ckeditor/ckeditor5-bookmark": "46.0.0",
+        "@ckeditor/ckeditor5-ckbox": "46.0.0",
+        "@ckeditor/ckeditor5-ckfinder": "46.0.0",
+        "@ckeditor/ckeditor5-clipboard": "46.0.0",
+        "@ckeditor/ckeditor5-cloud-services": "46.0.0",
+        "@ckeditor/ckeditor5-code-block": "46.0.0",
+        "@ckeditor/ckeditor5-core": "46.0.0",
+        "@ckeditor/ckeditor5-easy-image": "46.0.0",
+        "@ckeditor/ckeditor5-editor-balloon": "46.0.0",
+        "@ckeditor/ckeditor5-editor-classic": "46.0.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "46.0.0",
+        "@ckeditor/ckeditor5-editor-inline": "46.0.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "46.0.0",
+        "@ckeditor/ckeditor5-emoji": "46.0.0",
+        "@ckeditor/ckeditor5-engine": "46.0.0",
+        "@ckeditor/ckeditor5-enter": "46.0.0",
+        "@ckeditor/ckeditor5-essentials": "46.0.0",
+        "@ckeditor/ckeditor5-find-and-replace": "46.0.0",
+        "@ckeditor/ckeditor5-font": "46.0.0",
+        "@ckeditor/ckeditor5-fullscreen": "46.0.0",
+        "@ckeditor/ckeditor5-heading": "46.0.0",
+        "@ckeditor/ckeditor5-highlight": "46.0.0",
+        "@ckeditor/ckeditor5-horizontal-line": "46.0.0",
+        "@ckeditor/ckeditor5-html-embed": "46.0.0",
+        "@ckeditor/ckeditor5-html-support": "46.0.0",
+        "@ckeditor/ckeditor5-icons": "46.0.0",
+        "@ckeditor/ckeditor5-image": "46.0.0",
+        "@ckeditor/ckeditor5-indent": "46.0.0",
+        "@ckeditor/ckeditor5-language": "46.0.0",
+        "@ckeditor/ckeditor5-link": "46.0.0",
+        "@ckeditor/ckeditor5-list": "46.0.0",
+        "@ckeditor/ckeditor5-markdown-gfm": "46.0.0",
+        "@ckeditor/ckeditor5-media-embed": "46.0.0",
+        "@ckeditor/ckeditor5-mention": "46.0.0",
+        "@ckeditor/ckeditor5-minimap": "46.0.0",
+        "@ckeditor/ckeditor5-page-break": "46.0.0",
+        "@ckeditor/ckeditor5-paragraph": "46.0.0",
+        "@ckeditor/ckeditor5-paste-from-office": "46.0.0",
+        "@ckeditor/ckeditor5-remove-format": "46.0.0",
+        "@ckeditor/ckeditor5-restricted-editing": "46.0.0",
+        "@ckeditor/ckeditor5-select-all": "46.0.0",
+        "@ckeditor/ckeditor5-show-blocks": "46.0.0",
+        "@ckeditor/ckeditor5-source-editing": "46.0.0",
+        "@ckeditor/ckeditor5-special-characters": "46.0.0",
+        "@ckeditor/ckeditor5-style": "46.0.0",
+        "@ckeditor/ckeditor5-table": "46.0.0",
+        "@ckeditor/ckeditor5-theme-lark": "46.0.0",
+        "@ckeditor/ckeditor5-typing": "46.0.0",
+        "@ckeditor/ckeditor5-ui": "46.0.0",
+        "@ckeditor/ckeditor5-undo": "46.0.0",
+        "@ckeditor/ckeditor5-upload": "46.0.0",
+        "@ckeditor/ckeditor5-utils": "46.0.0",
+        "@ckeditor/ckeditor5-watchdog": "46.0.0",
+        "@ckeditor/ckeditor5-widget": "46.0.0",
+        "@ckeditor/ckeditor5-word-count": "46.0.0"
       }
     },
     "node_modules/clean-stack": {
@@ -6441,6 +6729,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -7246,6 +7544,29 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "dev": true,
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/decode-named-character-reference/node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -7365,6 +7686,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -7392,6 +7722,19 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -7791,9 +8134,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.38.0.tgz",
-      "integrity": "sha512-OT3AxczYYd3W50bCj4V0hKoOAfqIy9tof0leNQYekEDxVKir3RTVTJOLij7VAe6fsCNsGhC0JqIkURpMXTCSEA==",
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
       "dev": true
     },
     "node_modules/esbuild": {
@@ -9198,6 +9541,294 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-embedded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
+      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-has-property": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
+      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-body-ok-link": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
+      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
+      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-minify-whitespace/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/hast-util-minify-whitespace/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-embedded": "^3.0.0",
+        "hast-util-has-property": "^3.0.0",
+        "hast-util-is-body-ok-link": "^3.0.0",
+        "hast-util-is-element": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-dom": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-dom/-/hast-util-to-dom-4.0.1.tgz",
+      "integrity": "sha512-z1VE7sZ8uFzS2baF3LEflX1IPw2gSzrdo3QFEsyoi23MkCVY3FoE9x6nLgOgjwJu8VNWgo+07iaxtONhDzKrUQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "property-information": "^7.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/hast-util-to-html/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/hast-util-to-mdast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-mdast/-/hast-util-to-mdast-10.1.2.tgz",
+      "integrity": "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-phrasing": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-minify-whitespace": "^6.0.0",
+        "trim-trailing-lines": "^2.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-mdast/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/hast-util-to-mdast/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -9317,6 +9948,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/htmlparser2": {
@@ -11353,16 +11994,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
       "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/mathml-tag-names": {
@@ -11373,6 +12012,62 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -11386,6 +12081,963 @@
         "micromark": "~2.11.0",
         "parse-entities": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-gfm/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-newline-to-break/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-phrasing/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-phrasing/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/mdast-util-to-hast/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -11543,6 +13195,534 @@
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
       }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.7",
@@ -13933,6 +16113,16 @@
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -14342,6 +16532,362 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-dom-parse": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-parse/-/rehype-dom-parse-5.0.2.tgz",
+      "integrity": "sha512-8CqP11KaqvtWsMqVEC2yM3cZWZsDNqqpr8nPvogjraLuh45stabgcpXadCAxu1n6JaUNJ/Xr3GIqXP7okbNqLg==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/rehype-dom-parse/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-parse/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-stringify": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-dom-stringify/-/rehype-dom-stringify-4.0.2.tgz",
+      "integrity": "sha512-2HVFYbtmm5W3C2j8QsV9lcHdIMc2Yn/ytlPKcSC85/tRx2haZbU8V67Wxyh8STT38ZClvKlZ993Me/Hw8g88Aw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-dom": "^4.0.0",
+        "unified": "^11.0.0"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/rehype-dom-stringify/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-dom-stringify/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-minify-whitespace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/rehype-minify-whitespace/-/rehype-minify-whitespace-6.0.2.tgz",
+      "integrity": "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-minify-whitespace": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-remark/-/rehype-remark-10.0.1.tgz",
+      "integrity": "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "hast-util-to-mdast": "^10.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/rehype-remark/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-remark/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
@@ -14357,6 +16903,397 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/remark-breaks/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/remark-gfm/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm/node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
@@ -14364,6 +17301,130 @@
       "dev": true,
       "dependencies": {
         "mdast-util-from-markdown": "^0.8.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/remark-rehype/node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype/node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15967,6 +19028,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
@@ -16259,6 +19330,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities/node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -16924,6 +20019,16 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -16940,6 +20045,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-trailing-lines": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-2.1.0.tgz",
+      "integrity": "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/trough": {
@@ -17056,21 +20171,6 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
-    },
-    "node_modules/turndown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
-      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
-      "dev": true,
-      "dependencies": {
-        "@mixmark-io/domino": "^2.2.0"
-      }
-    },
-    "node_modules/turndown-plugin-gfm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
-      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -17317,6 +20417,39 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/unist-util-find-after/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-find-all-after": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
@@ -17340,6 +20473,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
     "node_modules/unist-util-stringify-position": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
@@ -17347,6 +20499,73 @@
       "dev": true,
       "dependencies": {
         "@types/unist": "^2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true
+    },
+    "node_modules/unist-util-visit/node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -17555,6 +20774,16 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "wproofreader"
   ],
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
     "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
     "@ckeditor/ckeditor5-package-tools": "^2.0.0",
-    "ckeditor5": "^43.0.0",
+    "ckeditor5": "0.0.0-nightly-20250624.0",
     "concurrently": "^8.0.1",
     "css-loader": "^6.7.3",
     "eslint": "^8.40.0",
@@ -66,5 +66,8 @@
   "peerDependencies": {
     "ckeditor5": ">=43.0.0"
   },
-  "types": "./src/index.d.ts"
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "typescript": "^5.8.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -66,8 +66,5 @@
   "peerDependencies": {
     "ckeditor5": ">=43.0.0"
   },
-  "types": "./src/index.d.ts",
-  "dependencies": {
-    "typescript": "^5.8.3"
-  }
+  "types": "./src/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "webpack-cli": "^5.1.1"
   },
   "peerDependencies": {
-    "ckeditor5": ">=43.0.0"
+    "ckeditor5": ">=46.0.0"
   },
   "types": "./src/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
     "@ckeditor/ckeditor5-package-tools": "^2.0.0",
-    "ckeditor5": "0.0.0-nightly-20250624.0",
+    "ckeditor5": "^46.0.0",
     "concurrently": "^8.0.1",
     "css-loader": "^6.7.3",
     "eslint": "^8.40.0",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "wproofreader"
   ],
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-build-tools": "^43.1.0",
+    "@ckeditor/ckeditor5-dev-utils": "^43.1.0",
     "@ckeditor/ckeditor5-package-tools": "^2.0.0",
     "ckeditor5": "^46.0.0",
     "concurrently": "^8.0.1",

--- a/src/wproofreaderui.js
+++ b/src/wproofreaderui.js
@@ -1,5 +1,5 @@
 import { Plugin } from 'ckeditor5/src/core.js';
-import { ViewModel, createDropdown, addListToDropdown } from 'ckeditor5/src/ui.js';
+import { UIModel, createDropdown, addListToDropdown } from 'ckeditor5/src/ui.js';
 import { Collection } from 'ckeditor5/src/utils.js';
 
 import wproofreaderIcon from '../theme/icons/wproofreader.svg';
@@ -107,7 +107,7 @@ export default class WProofreaderUI extends Plugin {
 		actions.forEach((action) => {
 			const definition = {
 				type: 'button',
-				model: new ViewModel({
+				model: new UIModel({
 					commandParam: this._commands[action.name],
 					label: action.localization.default,
 					localization: action.localization,


### PR DESCRIPTION
## Description

⚠️ This PR is a prepared to work with new release of CKEditor5 in v46.0.0 (that will be released within a few weeks). ⚠️

## Type of Change

`ViewWriter` will be no longer present in future versions of CKEditor. The `UIModel` should be used instead.

It's **breaking change**, older versions are no longer supported.

---

Closes: https://github.com/WebSpellChecker/wproofreader-ckeditor5/issues/98